### PR TITLE
Add trailing backslash to fix "not a directory" error

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -9,8 +9,8 @@ ADD mattermost /etc/nginx/sites-available/
 ADD docker-entry.sh /
 
 RUN mkdir /cert
-ADD cert/cert.pem /cert
-ADD cert/private/key-no-password.pem /cert
+ADD cert/cert.pem /cert/
+ADD cert/private/key-no-password.pem /cert/
 
 RUN chmod +x /docker-entry.sh
 


### PR DESCRIPTION
Running this Dockerfile on Fedora 22 throws a "not a directory" error when it reaches "ADD cert/cert.pem /cert". Adding a backslash to the path resolves the issue.