### PR TITLE
app: Upgrade Mattermost to 2.0.0

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -11,7 +11,7 @@ chdir /mattermost\n\
 exec bin/platform\n'\
 >> /etc/init/mattermost.conf
 
-RUN wget https://github.com/mattermost/platform/releases/download/v1.4.0/mattermost.tar.gz \
+RUN wget https://github.com/mattermost/platform/releases/download/v2.0.0/mattermost.tar.gz \
 	&& tar -xvzf mattermost.tar.gz && rm mattermost.tar.gz
 
 COPY config.template.json /


### PR DESCRIPTION
The new stable version is out :)

https://github.com/mattermost/platform/releases/tag/v2.0.0